### PR TITLE
fix: bump openjdk base image version (1.23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.13 AS builder
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.23 AS builder
 WORKDIR /work
 COPY . .
 USER 0
 RUN mvn clean package -DskipTests -DskipDocsGen
 
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.23
 USER 185
 WORKDIR /work/
 


### PR DESCRIPTION
addresses the error

```
Error: unable to copy from source docker://registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13: copying system image from manifest list: Source image rejected: None of the signatures were accepted, reasons: Signature for identity "[registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13-1.1655306380](http://registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13-1.1655306380)" is not accepted;
```